### PR TITLE
Disable scroll and click linking with ghost mode settings

### DIFF
--- a/lib/stencil-start.js
+++ b/lib/stencil-start.js
@@ -233,6 +233,11 @@ class StencilStart {
             },
             proxy: `localhost:${stencilConfig.port}`,
             tunnel,
+            ghostMode: {
+                clicks: false,
+                forms: true,
+                scroll: false
+            }
         });
 
         // Handle manual reloading of browsers by typing 'rs';


### PR DESCRIPTION
Disable scroll and click linking with ghost mode settings