### PR TITLE
Log Missing Config.json Keys During Stencil Pull

### DIFF
--- a/lib/stencil-pull.utils.js
+++ b/lib/stencil-pull.utils.js
@@ -71,6 +71,7 @@ utils.mergeThemeConfiguration = async (options) => {
     // overwrite the local configuration if the remote configuration differs
     for (const [key, remoteVal] of Object.entries(remoteThemeConfiguration.settings)) {
         if (!(key in localConfig.settings)) {
+            console.log(`🚀 -- Skipping key "${key}" as it does not exist in local configuration`);
             continue;
         }
         const defaultVal = localConfig.settings[key];


### PR DESCRIPTION
- Console log which config.json keys are not found in the default theme settings, so you have a chance to add them. Otherwise, any theme variant settings that don't exist in default settings will never be saved from the live store when doing a `stencil pull`