### PR TITLE
Use dart-sass instead of node-sass to fix source map line numbers

### DIFF
--- a/lib/css/compile.js
+++ b/lib/css/compile.js
@@ -1,7 +1,7 @@
 import path from 'path';
 import StencilStyles from '@bigcommerce/stencil-styles';
 
-const SASS_ENGINE_NAME = 'node-sass';
+const SASS_ENGINE_NAME = 'dart-sass';
 const compile = async (configuration, themeAssetsPath, fileName, engineName = SASS_ENGINE_NAME) => {
     const fileParts = path.parse(fileName);
     const ext = configuration.css_compiler === 'css' ? configuration.css_compiler : 'scss';


### PR DESCRIPTION
- feat: Use dart-sass instead of node-sass to fix source map line numbers. Known issue with node-sass.

#### What?

A description about what this pull request implements and its purpose. Try to be detailed and describe any technical details to simplify the job of the reviewer and the individual on production support.

#### Tickets / Documentation

Add links to any relevant tickets and documentation.

-   [Link 1](http://example.com)
-   ...

#### Screenshots (if appropriate)

Attach images or add image links here.

![Example Image](http://placehold.it/300x200)

cc @bigcommerce/storefront-team
